### PR TITLE
Support for non-interactive setup script

### DIFF
--- a/install-epics.sh
+++ b/install-epics.sh
@@ -74,18 +74,18 @@ EPICS_ROOT=$(echo $EPICS_ROOT | sed -e "s%/[^/][^/]*/\.\./%/%")
 # Automatic install option for scripted installation
 INSTALL_EPICS=""
 
-while getopts ":e:" opt; do
+while getopts ":i:" opt; do
   case $opt in
     e)
       INSTALL_EPICS=$OPTARG
       ;;
     :)
-      echo "Option -e needs an argument, y for automatic installation of EPICS."
-      exit 0
+      echo "Option -i needs an argument (y for automatic installation of EPICS, n for skipping installation)."
+      exit 1
    esac
 done
 
-if [ -z "$INSTALL_EPICS" ]; then
+if test -z "$INSTALL_EPICS"; then
   echo EPICS_ROOT=$EPICS_ROOT
   echo Do you want to install EPICS in $EPICS_ROOT ? [y/N]
   read yesno

--- a/install-epics.sh
+++ b/install-epics.sh
@@ -76,7 +76,7 @@ INSTALL_EPICS=""
 
 while getopts ":i:" opt; do
   case $opt in
-    e)
+    i)
       INSTALL_EPICS=$OPTARG
       ;;
     :)

--- a/install-epics.sh
+++ b/install-epics.sh
@@ -71,16 +71,34 @@ echo EPICS_ROOT=$EPICS_ROOT
 EPICS_ROOT=$(echo $EPICS_ROOT | sed -e "s%/[^/][^/]*/\.\./%/%")
 
 
+# Automatic install option for scripted installation
+INSTALL_EPICS=""
 
-echo EPICS_ROOT=$EPICS_ROOT
-echo Do you want to install EPICS in $EPICS_ROOT ? [y/N]
-read yesno
-case $yesno in
+while getopts ":e:" opt; do
+  case $opt in
+    e)
+      INSTALL_EPICS=$OPTARG
+      ;;
+    :)
+      echo "Option -e needs an argument, y for automatic installation of EPICS."
+      exit 0
+   esac
+done
+
+if [ -z "$INSTALL_EPICS" ]; then
+  echo EPICS_ROOT=$EPICS_ROOT
+  echo Do you want to install EPICS in $EPICS_ROOT ? [y/N]
+  read yesno
+  INSTALL_EPICS=$yesno
+fi
+
+case $INSTALL_EPICS in
   y|Y)
   ;;
   *)
   exit 0
 esac
+
 
 if $(echo "$EPICS_ROOT" | grep -q /usr/local); then
 	echo EPICS_ROOT=$EPICS_ROOT

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-./install-epics.sh
+./install-epics.sh "$@"
 DIR=m-epics-IcePAP
 if ! test -d "$DIR"; then	
   git clone https://github.com/EuropeanSpallationSource/$DIR.git &&


### PR DESCRIPTION
This adds an option to the `install-epics.sh`-script which lets the user specify an argument to replace the interactive question for installation of EPICS. See the first commit message for details.
